### PR TITLE
Fix clippy warning

### DIFF
--- a/src/master_skull_upgrade_helper.rs
+++ b/src/master_skull_upgrade_helper.rs
@@ -225,7 +225,7 @@ async fn do_requests_and_extract_prices(
 
 #[inline]
 async fn parse_request_and_insert_prices(
-    prices: &mut IntMap<usize, i64>,
+    prices: &IntMap<usize, i64>,
     i: usize,
     result_of_request: Result<Response, Error>,
 ) -> bool {


### PR DESCRIPTION
# Changes made in this Pull Request

Fixes clippy warning about unnecessary mut reference.

# Reason of the above changes are

Less warnings = better

# Other information about this Pull Request

N/A